### PR TITLE
Remove superfluous slashes when building request URLs

### DIFF
--- a/moj_auth/__init__.py
+++ b/moj_auth/__init__.py
@@ -86,6 +86,7 @@ def get_user(request):
 
     return user or MojAnonymousUser()
 
+
 def get_user_model():
     try:
         return import_string(settings.MOJ_USER_MODEL)
@@ -115,3 +116,7 @@ def logout(request):
 
     if hasattr(request, 'user'):
         request.user = MojAnonymousUser()
+
+
+def urljoin(base, *parts):
+    return '/'.join([s.strip('/') for s in [base] + list(parts)]) + '/'

--- a/moj_auth/api_client.py
+++ b/moj_auth/api_client.py
@@ -8,7 +8,7 @@ from oauthlib.oauth2 import LegacyApplicationClient
 
 from django.conf import settings
 
-from . import update_token_in_session
+from . import update_token_in_session, urljoin
 from .exceptions import Unauthorized
 
 
@@ -16,10 +16,7 @@ from .exceptions import Unauthorized
 if settings.OAUTHLIB_INSECURE_TRANSPORT:
     os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
 
-
-REQUEST_TOKEN_URL = '{base_url}/oauth2/token/'.format(
-    base_url=settings.API_URL
-)
+REQUEST_TOKEN_URL = urljoin(settings.API_URL, '/oauth2/token/')
 
 
 def response_hook(response, *args, **kwargs):


### PR DESCRIPTION
Resolve #4 

The URLs in the auth library were being built using a format string
method which could lead to superfluous slashes in the path. Now use
a join method which will always have a single slash between path
elements.
