### PR TITLE
ensures a ValidationError is raised if a user enters an invalid username / password

### DIFF
--- a/moj_auth/forms.py
+++ b/moj_auth/forms.py
@@ -2,8 +2,9 @@ from requests.exceptions import ConnectionError
 
 from django import forms
 from django.contrib.auth import authenticate
-
 from django.utils.translation import ugettext_lazy as _
+
+from .exceptions import Unauthorized
 
 
 class AuthenticationForm(forms.Form):
@@ -34,17 +35,19 @@ class AuthenticationForm(forms.Form):
                     username=username, password=password
                 )
                 # if authenticate returns None it means that the
-                # credentials were wront
+                # credentials were wrong
                 if self.user_cache is None:
-                    raise forms.ValidationError(
-                        self.error_messages['invalid_login'],
-                        code='invalid_login',
-                    )
+                    raise Unauthorized
             except ConnectionError:
                 # in case of problems connecting to the api server
                 raise forms.ValidationError(
                     self.error_messages['connection_error'],
                     code='connection_error',
+                )
+            except Unauthorized:
+                raise forms.ValidationError(
+                    self.error_messages['invalid_login'],
+                    code='invalid_login',
                 )
 
         return self.cleaned_data


### PR DESCRIPTION
because an uncaught Unauthorized exception was raised in api_client.authenticate (from MoJOAuth2Session's response_hook) while the form was expecting None as a return value
