### PR TITLE
Fix bug related to requests_oauthlib 0.6

### DIFF
--- a/moj_auth/api_client.py
+++ b/moj_auth/api_client.py
@@ -62,7 +62,8 @@ def authenticate(username, password):
             username=username,
             password=password,
             client_id=settings.API_CLIENT_ID,
-            client_secret=settings.API_CLIENT_SECRET
+            client_secret=settings.API_CLIENT_SECRET,
+            encoding='utf-8'
         )
 
         conn = _get_slumber_connection(session)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-moj-auth',
-    version='0.5',
+    version='0.6',
     packages=['moj_auth', 'moj_auth.tests'],
     include_package_data=True,
     license='BSD License',


### PR DESCRIPTION
Due to a change in requests_oauthlib 0.6 which always
includes a basic auth header, this activates a code
branch in oauth2_provider which results in an AttributeError
if the request's encoding is not set. To fix, set the encoding
to utf-8.
