### PR TITLE
Add views and form for changing a remote user's password

### DIFF
--- a/moj_auth/forms.py
+++ b/moj_auth/forms.py
@@ -1,10 +1,12 @@
 from django import forms
-from django.contrib.auth import authenticate
+from django.contrib.auth import authenticate, password_validation
 from django.utils.translation import ugettext_lazy as _
 from form_error_reporting import GARequestErrorReportingMixin
 from requests.exceptions import ConnectionError
+from slumber.exceptions import HttpClientError
 
 from .exceptions import Unauthorized
+from . import api_client
 
 
 class AuthenticationForm(GARequestErrorReportingMixin, forms.Form):
@@ -54,3 +56,53 @@ class AuthenticationForm(GARequestErrorReportingMixin, forms.Form):
 
     def get_user(self):
         return self.user_cache
+
+
+class PasswordChangeForm(GARequestErrorReportingMixin, forms.Form):
+    """
+    A form that lets a user change their password by entering their old
+    password.
+    """
+    error_messages = {
+        'password_mismatch': _("The two password fields didn't match."),
+        'password_incorrect': _("Your old password was entered incorrectly. "
+                                "Please enter it again."),
+    }
+    old_password = forms.CharField(label=_("Old password"),
+                                   widget=forms.PasswordInput)
+    new_password1 = forms.CharField(label=_("New password"),
+                                    widget=forms.PasswordInput,
+                                    help_text=password_validation.password_validators_help_text_html())
+    new_password2 = forms.CharField(label=_("New password confirmation"),
+                                    widget=forms.PasswordInput)
+
+    def __init__(self, request=None, user=None, *args, **kwargs):
+        self.request = request
+        self.user = user
+        super(PasswordChangeForm, self).__init__(*args, **kwargs)
+
+    def clean_new_password2(self):
+        password1 = self.cleaned_data.get('new_password1')
+        password2 = self.cleaned_data.get('new_password2')
+        if password1 and password2:
+            if password1 != password2:
+                raise forms.ValidationError(
+                    self.error_messages['password_mismatch'],
+                    code='password_mismatch',
+                )
+        password_validation.validate_password(password2, self.user)
+        return password2
+
+    def clean(self):
+        if self.is_valid():
+            old_password = self.cleaned_data.get('old_password')
+            new_password = self.cleaned_data.get('new_password2')
+            try:
+                api_client.get_connection(self.request).change_password.post(
+                    {'old_password': old_password, 'new_password': new_password}
+                )
+            except HttpClientError:
+                raise forms.ValidationError(
+                    self.error_messages['password_incorrect'],
+                    code='invalid_login'
+                )

--- a/moj_auth/tests/urls.py
+++ b/moj_auth/tests/urls.py
@@ -10,8 +10,19 @@ urlpatterns = [
         }, name='login'),
     url(
         r'^logout/$', views.logout, {
-            'template_name': 'login.html',
+            'template_name': 'logout.html',
             'next_page': 'dummy-view',
         }, name='logout'
+    ),
+    url(
+        r'^password_change/$', views.password_change, {
+            'template_name': 'login.html',
+        }, name='password_change'
+    ),
+    url(
+        r'^password_change_done/$', views.password_change_done, {
+            'template_name': 'done.html',
+        },
+        name='password_change_done'
     ),
 ]

--- a/runtests.py
+++ b/runtests.py
@@ -28,6 +28,8 @@ DEFAULT_SETTINGS = dict(
     ),
     INSTALLED_APPS=(
         'django.contrib.sessions',
+        'django.contrib.contenttypes',
+        'django.contrib.auth',
         'moj_auth',
     ),
     TEMPLATES=[{


### PR DESCRIPTION
Provides shared views to allow for giving an authenticated user
the ability to change their own password on the backend.
